### PR TITLE
Create fieldTypes.js

### DIFF
--- a/lib/fieldTypes.js
+++ b/lib/fieldTypes.js
@@ -1,0 +1,10 @@
+var objectID = {
+    name: "{\r"+
+    "\t \t type: mongoose.Schema.ObjectId, \r"+
+    "\t \t ref: '{ref}' \r"+
+    "\t }"
+};
+
+module.exports = {
+	objectID: objectID
+};


### PR DESCRIPTION
provides a file to define field types (currently, only objectID is defined there)
