### PR TITLE
added fieldTypes.js require and format modelFields

### DIFF
--- a/lib/formatTools.js
+++ b/lib/formatTools.js
@@ -1,10 +1,12 @@
 
+var fieldTypes = require('./fieldTypes');
 var allowedFieldsTypes = {
     "string" : String,
     "number" : Number,
     "date"   : Date,
     "boolean": Boolean,
-    "array"  : Array
+    "array"  : Array,
+    "objectID": fieldTypes.objectID
 };
 
 /**
@@ -19,6 +21,9 @@ function getFieldsForModelTemplate(fields){
     fields.forEach(function(field, index, array){
         modelFields += '\t"' + field.name + '" : ' + (allowedFieldsTypes[field.type]).name;
         modelFields += (lg > index) ? ',\r' : '\r';
+        if(field.ref){
+            modelFields = modelFields.replace(/{ref}/, field.ref );
+        }
     });
     modelFields += '}';
 


### PR DESCRIPTION
Ok so ObjectID type comes from fieldTypes.js, so we require it and defiine it in the array (should be done with other field types too).

Bellow, theres this if() to check if field has a ref property. if it does, it will replate the {ref} template
